### PR TITLE
Added a first draft for the implementations' list

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,17 +20,23 @@
 
     <h3>Documents and drafts</h3>
     <ul>
-    <li><a href="https://www.w3.org/TR/verifiable-claims-use-cases/">Verifiable Credentials Use Cases</a>
-        <ul>
-            <li><a href="https://w3c.github.io/vc-use-cases/">editor’s draft</a></li>
-            <li><a href="https://github.com/w3c/vc-data-model/">github page with issue tracker</a></li>
-        </ul>
-    <li><a href="https://www.w3.org/TR/verifiable-claims-data-model/">Verifiable Credentials Data Model and Representations</a>
-        <ul>
-            <li><a href="https://w3c.github.io/vc-data-model/">editor’s draft</a></li>             
-            <li><a href="https://github.com/w3c/vc-use-cases/">github page with issue tracker</a></li>
-        </ul>
-    </li>
+        <li>
+            <a href="https://www.w3.org/TR/verifiable-claims-data-model/">Verifiable Credentials Data Model</a>
+            <ul>
+                <li><a href="https://w3c.github.io/vc-data-model/">editor’s draft</a></li>             
+                <li><a href="https://github.com/w3c/vc-use-cases/">github</a></li>
+            </ul>
+        </li>
+        <li>
+            <a href="https://www.w3.org/TR/verifiable-claims-use-cases/">Verifiable Credentials Use Cases</a>
+            <ul>
+                <li><a href="https://w3c.github.io/vc-use-cases/">editor’s draft</a></li>
+                <li><a href="https://github.com/w3c/vc-data-model/">github</a></li>
+            </ul>
+        </li>
+        <li>
+            <a href="implementations">List of implementations</a>
+        </li>
     </ul>
 
     <h3>Group details</h3>

--- a/implementations.md
+++ b/implementations.md
@@ -5,20 +5,23 @@ title: VC Implementations
 
 # List of Implementations for the Verifiable Credentials Data Model
 
+- Go
+  - [Credential Manifest Builders](https://github.com/TBD54566975/ssi-sdk/tree/main/credential) (DI & JWT)
+  - [Hyperledger Aries Framework Go](https://github.com/hyperledger/aries-framework-go) (DI & JWT)
+- Java
+  - [Verifiable Credentials Java](https://github.com/danubetech/verifiable-credentials-java) (DI & JWT)
 - JavaScript/TypeScript
   - [Verifiable Credentials JS Library](https://github.com/digitalbazaar/vc-js) (DI)
   - [Verifiable Data Credential JS Library with JWT](https://github.com/transmute-industries/verifiable-data/tree/main/packages/vc.js) (DI & JWT)
   - [W3C Verifiable Credentials and Presentations in JWT format](https://github.com/decentralized-identity/did-jwt-vc) (JWT)
-  - [Cryptographic Primitives used for DID](https://github.com/microsoft/VerifiableCredential-SDK-Android, https://github.com/microsoft/VerifiableCredential-SDK-iOS) (JWT)
-- Go
-  - [Hyperledger Aries Framework Go](https://github.com/hyperledger/aries-framework-go) (DI & JWT)
-  - [Credential Manifest Builders](https://github.com/TBD54566975/ssi-sdk/tree/main/credential) (DI & JWT)
-- Rust
-  - [DIDKit](https://github.com/spruceid/didkit) (DI & JWT)
+- Kotlin
+  - [Verifiable Credentials in Kotlin](https://github.com/microsoft/VerifiableCredential-SDK-Android) (JWT)
 - Python
   - [Hyperledger Aries Cloud Agent - Python (ACA-Py)](https://github.com/hyperledger/aries-cloudagent-python) (DI & JWT)
-- Java
-  - [Verifiable Credentials Java](https://github.com/danubetech/verifiable-credentials-java) (DI & JWT)
+- Rust
+  - [DIDKit](https://github.com/spruceid/didkit) (DI & JWT)
+- Swift
+  - [Verifiable Credentials in Swift](https://github.com/microsoft/VerifiableCredential-SDK-iOS) (JWT)
 
 
 This list is maintained by the community. To add/change/remove an item, please provide a Pull Request for the `implementations.md` file on the [Working Group Repository](https://github.com/w3c/verifiable-credentials/).

--- a/implementations.md
+++ b/implementations.md
@@ -5,7 +5,7 @@ title: VC Implementations
 
 # List of Implementations for the Verifiable Credentials Data Model
 
-- Javascript/Typescript
+- JavaScript/TypeScript
   - [Verifiable Credentials JS Library](https://github.com/digitalbazaar/vc-js) (DI)
   - [Verifiable Data Credential JS Library with JWT](https://github.com/transmute-industries/verifiable-data/tree/main/packages/vc.js) (DI & JWT)
   - [W3C Verifiable Credentials and Presentations in JWT format](https://github.com/decentralized-identity/did-jwt-vc) (JWT)

--- a/implementations.md
+++ b/implementations.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title: VC Implementations
+---
+
+# List of Implementations for the Verifiable Credentials Data Model
+
+- Javascript/Typescript
+  - [Verifiable Credentials JS Library](https://github.com/digitalbazaar/vc-js) (DI)
+  - [Verifiable Data Credential JS Library with JWT](https://github.com/transmute-industries/verifiable-data/tree/main/packages/vc.js),(DI & JWT)
+  - [W3C Verifiable Credentials and Presentations in JWT format](https://github.com/decentralized-identity/did-jwt-vc) (JWT)
+  - [Cryptographic Primitives used for DID](https://github.com/microsoft/VerifiableCredentials-Crypto-SDK-Typescript) (JWT)
+- Go
+  - [Hyperledger Aries Framework Go](https://github.com/hyperledger/aries-framework-go) (DI & JWT)
+  - [Credential Manifest Builders](https://github.com/TBD54566975/ssi-sdk/tree/main/credential) (DI & JWT)
+- Rust
+  - [DIDKit](https://github.com/spruceid/didkit) (DI & JWT)
+- Python
+  - [Hyperledger Aries Cloud Agent - Python (ACA-Py)](https://github.com/hyperledger/aries-cloudagent-python) (DI & JWT)
+- Python
+  - [Verifiable Credentials Java](https://github.com/danubetech/verifiable-credentials-java) (DI & JWT)
+
+
+This list is maintained by the community. To add/change/remove an item, please provide a Pull Request for the `implementations.md` file on the [Working Group Repository](https://github.com/w3c/verifiable-credentials/).

--- a/implementations.md
+++ b/implementations.md
@@ -17,7 +17,7 @@ title: VC Implementations
   - [DIDKit](https://github.com/spruceid/didkit) (DI & JWT)
 - Python
   - [Hyperledger Aries Cloud Agent - Python (ACA-Py)](https://github.com/hyperledger/aries-cloudagent-python) (DI & JWT)
-- Python
+- Java
   - [Verifiable Credentials Java](https://github.com/danubetech/verifiable-credentials-java) (DI & JWT)
 
 

--- a/implementations.md
+++ b/implementations.md
@@ -7,7 +7,7 @@ title: VC Implementations
 
 - Javascript/Typescript
   - [Verifiable Credentials JS Library](https://github.com/digitalbazaar/vc-js) (DI)
-  - [Verifiable Data Credential JS Library with JWT](https://github.com/transmute-industries/verifiable-data/tree/main/packages/vc.js),(DI & JWT)
+  - [Verifiable Data Credential JS Library with JWT](https://github.com/transmute-industries/verifiable-data/tree/main/packages/vc.js) (DI & JWT)
   - [W3C Verifiable Credentials and Presentations in JWT format](https://github.com/decentralized-identity/did-jwt-vc) (JWT)
   - [Cryptographic Primitives used for DID](https://github.com/microsoft/VerifiableCredentials-Crypto-SDK-Typescript) (JWT)
 - Go

--- a/implementations.md
+++ b/implementations.md
@@ -9,7 +9,7 @@ title: VC Implementations
   - [Verifiable Credentials JS Library](https://github.com/digitalbazaar/vc-js) (DI)
   - [Verifiable Data Credential JS Library with JWT](https://github.com/transmute-industries/verifiable-data/tree/main/packages/vc.js) (DI & JWT)
   - [W3C Verifiable Credentials and Presentations in JWT format](https://github.com/decentralized-identity/did-jwt-vc) (JWT)
-  - [Cryptographic Primitives used for DID](https://github.com/microsoft/VerifiableCredentials-Crypto-SDK-Typescript) (JWT)
+  - [Cryptographic Primitives used for DID](https://github.com/microsoft/VerifiableCredential-SDK-Android, https://github.com/microsoft/VerifiableCredential-SDK-iOS) (JWT)
 - Go
   - [Hyperledger Aries Framework Go](https://github.com/hyperledger/aries-framework-go) (DI & JWT)
   - [Credential Manifest Builders](https://github.com/TBD54566975/ssi-sdk/tree/main/credential) (DI & JWT)


### PR DESCRIPTION
This PR fixes #39, #40, #38

I added the list of implementations as listed in https://github.com/w3c/verifiable-credentials/issues/39#issuecomment-1134671805 and https://github.com/w3c/verifiable-credentials/issues/39#issuecomment-1144106832. I tried to turn them into something more readable and, as a first step, categorized them by programming languages. All this is really to get the ball rolling.

However, I am not sure about all the entries. Some entries have a minimal readme file (if any!) which makes it difficult to list them (improvement on those would be good). Also, the [Microsoft entry](https://github.com/microsoft/VerifiableCredentials-Crypto-SDK-Typescript) seems to concentrate on DID and not VC, I am not sure whether it is really to be listed here. Bottom line: I need help to clean this up.

I have also added a paragraph asking people to provide PR-s for changes or additions. We will have to discuss, at some points, some basic rules as for which PR-s we should accept and which ones should be turned down.