### PR TITLE
Updating the WG Web site

### DIFF
--- a/Meetings/index.md
+++ b/Meetings/index.md
@@ -17,7 +17,7 @@ The meeting schedules are:
 * On odd weeks: Tuesdays, 11:00-12:00 US Eastern Time (“Europe-Africa Friendly" calls)
 * On even weeks: Tuesdays, 18:00-19:00 US Eastern Time (“Asia-Pacific Friendly” calls)
 
-See the groups [calendar page](https://www.w3.org/groups/wg/vc/calendar) for the entries in the WG calendar (group members can “subscribe” to the calendar items through their [personal calendar](https://www.w3.org/users/myprofile/calendar), see the “export” tab).
+See the group's [calendar page](https://www.w3.org/groups/wg/vc/calendar) for the entries in the WG calendar. (Group members can “subscribe” to the calendar items through their [personal calendar](https://www.w3.org/users/myprofile/calendar); see the “export” tab.)
 See also the [separate page](./zoom) for further information on the Zoom bridge.
 
 The Group also uses IRC for during the calls for minute taking, queue control, and general chit-chat. See the [separate page at W3C](https://www.w3.org/Project/IRC/) for further details. This Working Group uses the `#vc` channel, and makes use of two bots on IRC:

--- a/Meetings/index.md
+++ b/Meetings/index.md
@@ -28,8 +28,6 @@ The Group also uses IRC for during the calls for minute taking, queue control, a
 
 ## F2F meetings
 
-* [April 6, 2018, Mountain view](F2F/201804f2f.md)
-* [March 4-5, 2019 (Barcelona)](F2F/Barcelona.md)
 * September 15-16, 2022 (Vancouver) (T.B.D.)
 
 ## Meeting Minutes

--- a/Meetings/index.md
+++ b/Meetings/index.md
@@ -10,7 +10,7 @@ layout: default
 
 ## Teleconferences
 
-The weekly teleconferences on Tuesdays at various times to allow for all geographical areas to participate on calls at least 1-2 times.
+The weekly teleconferences on Tuesdays at various times to allow for all geographical areas to participate on calls at least 1-2 times per month.
 <!-- See the (member only) [notification](https://lists.w3.org/Archives/Member/member-did-wg/2020Apr/0007.html) for the details.  --> 
 The meeting schedules are:
 

--- a/Meetings/index.md
+++ b/Meetings/index.md
@@ -10,7 +10,7 @@ layout: default
 
 ## Teleconferences
 
-The weekly teleconferences on Tuesdays at various times to allow for all geographical areas to participate on calls at least 1-2 times per month.
+The weekly teleconferences on Tuesdays with rotating time slots to allow for all geographical areas to participate on calls at least 1-2 times per month.
 <!-- See the (member only) [notification](https://lists.w3.org/Archives/Member/member-did-wg/2020Apr/0007.html) for the details.  --> 
 The meeting schedules are:
 

--- a/Meetings/index.md
+++ b/Meetings/index.md
@@ -10,7 +10,15 @@ layout: default
 
 ## Teleconferences
 
-There are no regular teleconferences.
+The weekly teleconferences on Tuesdays at various times to allow for all geographical areas to participate on calls at least 1-2 times.
+<!-- See the (member only) [notification](https://lists.w3.org/Archives/Member/member-did-wg/2020Apr/0007.html) for the details.  --> 
+The meeting schedules are:
+
+* On odd weeks: Tuesdays, 11:00-12:00 US Eastern Time (“Europe-Africa Friendly" calls)
+* On even weeks: Tuesdays, 18:00-19:00 US Eastern Time (“Asia-Pacific Friendly” calls)
+
+See the groups [calendar page](https://www.w3.org/groups/wg/vc/calendar) for the entries in the WG calendar (group members can “subscribe” to the calendar items through their [personal calendar](https://www.w3.org/users/myprofile/calendar), see the “export” tab).
+See also the [separate page](./zoom) for further information on the Zoom bridge.
 
 The Group also uses IRC for during the calls for minute taking, queue control, and general chit-chat. See the [separate page at W3C](https://www.w3.org/Project/IRC/) for further details. This Working Group uses the `#vc` channel, and makes use of two bots on IRC:
 
@@ -20,7 +28,9 @@ The Group also uses IRC for during the calls for minute taking, queue control, a
 
 ## F2F meetings
 
-No meeting planned
+* [April 6, 2018, Mountain view](F2F/201804f2f.md)
+* [March 4-5, 2019 (Barcelona)](F2F/Barcelona.md)
+* September 15-16, 2022 (Vancouver) (T.B.D.)
 
 ## Meeting Minutes
 

--- a/Meetings/index.md
+++ b/Meetings/index.md
@@ -10,12 +10,12 @@ layout: default
 
 ## Teleconferences
 
-The weekly teleconferences on Tuesdays with rotating time slots to allow for all geographical areas to participate on calls at least 1-2 times per month.
+There are weekly teleconferences on Wednesdays with rotating time slots to allow for all geographical areas to participate on calls at least 1-2 times per month.
 <!-- See the (member only) [notification](https://lists.w3.org/Archives/Member/member-did-wg/2020Apr/0007.html) for the details.  --> 
 The meeting schedules are:
 
-* On odd weeks: Tuesdays, 11:00-12:00 US Eastern Time (“Europe-Africa Friendly" calls)
-* On even weeks: Tuesdays, 18:00-19:00 US Eastern Time (“Asia-Pacific Friendly” calls)
+* On odd weeks: Wednesdays, 11:00-12:00 US Eastern Time (“Europe-Africa Friendly" calls)
+* On even weeks: Wednesdays, 15:00-16:00 US Eastern Time (“Asia-Pacific Friendly” calls)
 
 See the group's [calendar page](https://www.w3.org/groups/wg/vc/calendar) for the entries in the WG calendar. (Group members can “subscribe” to the calendar items through their [personal calendar](https://www.w3.org/users/myprofile/calendar); see the “export” tab.)
 See also the [separate page](./zoom) for further information on the Zoom bridge.

--- a/Meetings/zoom.md
+++ b/Meetings/zoom.md
@@ -7,7 +7,7 @@ layout: default
 
 The group uses MIT’s Zoom Account for the calls.
 
-**Joining the call is restricted to the official members of the DID Working Group.** Joining the group for representatives of W3C Members can be done via the [join form](https://www.w3.org/2004/01/pp-impl/98922/join) (this form must be filled by the AC representative of the Member organization).
+**Joining the call is restricted to the official members of the VC Working Group.** Joining the group for representatives of W3C Members can be done via the [join form](https://www.w3.org/2004/01/pp-impl/98922/join) (this form must be filled by the AC representative of the Member organization).
 
 ---
 

--- a/Meetings/zoom.md
+++ b/Meetings/zoom.md
@@ -1,0 +1,18 @@
+---
+layout: default
+---
+
+# Zoom information for regular calls
+{: .no_toc}
+
+The group uses MIT’s Zoom Account for the calls.
+
+**Joining the call is restricted to the official members of the DID Working Group.** Joining the group for representatives of W3C Members can be done via the [join form](https://www.w3.org/2004/01/pp-impl/98922/join) (this form must be filled by the AC representative of the Member organization).
+
+---
+
+## Teleconference Logistics
+
+* Zoom can be used via dial-in as well as from a Web Browser or an app via a meeting ID or a URL. 
+* See [the group calendar entries](https://www.w3.org/groups/wg/vc/calendar) for further details on the dial numbers and the call details. (This is a member-only link!).
+* Further information on Zoom are available on the [W3C zoom page](https://www.w3.org/Guide/meetings/zoom.html).

--- a/WorkMode/getting-started.md
+++ b/WorkMode/getting-started.md
@@ -1,0 +1,96 @@
+---
+layout: default
+---
+# Welcome to the VC Working Group
+{: .no_toc}
+
+This document includes some information for new members of the DID Working
+Group (VC WG).
+
+Members of the WG, **especially new members** are encouraged to help
+maintain this document.
+
+* TOC
+{:toc}
+
+The Working Group’s home page is:
+[https://www.w3.org/2017/vc/WG/](https://www.w3.org/2017/vc/WG/). Looking
+at the left and right column of the page gives you lots of further
+information. Especially, the group's *Work Mode* is described in the
+[*WorkMode*](index) document and it includes information about how the WG
+operates, including links to the WG's various resources.
+
+## Meetings
+
+The group holds a weekly teleconference; see
+[the times and dial-in details](../Meetings/).
+
+## GitHub
+
+The group operates mostly on [GitHub](index#github): that is where the
+specifications are developed, where issues are discussed. Even these pages
+are in a GitHub repository (look at the bottom for the reference). It is
+therefore important to familiarize yourself, at least at a basic level,
+with this tool. (If you are new to GitHub, the
+[*“Introduction to Basic GitHub Contribution”*](https://iherman.github.io/misc-notes/docs/BasicGitHubContributionIntro)
+may be of help.)
+
+Once you have your GitHub account name, **send this name to ivan@w3.org, or
+to one of the chairs**, who will add you to the Working Group’s “GitHub
+team” (in GitHub‘s jargon). That would enable you to be
+asked personally to review or be assigned to issues, or to edit the wiki
+pages.
+
+You should also "link" your GitHub account to your W3C account; this can be
+done by going to the
+[relevant page](https://www.w3.org/users/myprofile/connectedaccounts) on
+your account. Doing so ensures that the various W3C specific tools can
+check your identity whether you use your W3C account or your GitHub
+account. As an example, if you do a Pull Request on one of the
+Recommendation track documents on GitHub, the system would know that you
+are a Working Group member, which means that the possible IPR issues are
+properly handled by virtue of your institution’s Working Group membership.
+
+## IRC
+
+Meetings usually use [IRC](index#irc) as a tool for queue control and
+minute taking (and general chit-chat). **You should also send ivan@w3.org
+your preferred IRC nickname(s).**
+The goal is to improve the readability of the meeting minutes, so that
+third parties can also understand whose comments and remarks are in the
+minutes. If you are already a seasoned GitHub user: the
+IRC and GitHub nicknames are stored (of course :-) ) in a
+[file on GitHub](https://github.com/w3c/did-wg/blob/master/assets/nicknames.json),
+meaning that you can simply make a pull request adding your nickname(s)
+instead of sending an e-mail.
+
+## Specifications in Progress
+
+A list of the group’s specifications, including the publication status of
+each spec, can be found in the group’s
+[publications’ page](https://www.w3.org/groups/wg/vc/publications).
+
+## New WG Member Introductions
+
+Although it isn’t required, **new WG members are encouraged to send a short
+introductory e-mail to the WG's Public mail list**
+([public-vc-wg@w3.org](https://lists.w3.org/Archives/Public/public-vc-wg/))
+or the group’s Member-only list
+([member-vc-wg@w3.org](https://lists.w3.org/Archives/Member/member-vc-wg/)).
+The introduction should include your area(s) of interest.
+
+New WG members may also be invited to introduce themselves during a 
+teleconference meeting.
+
+## Questions, Comments, Issues, etc.?
+
+Please contact the group's Chairs and staff contacts (using the
+[group-vc-wg-chairs@w3.org](mailto:group-vc-wg-chairs@w3.org) list) — *at
+any time* — if you have any questions, issues, concerns, etc., about the
+Working Group.
+
+## Resources
+
+If you are unfamiliar with processes and roles within the Consortium; there
+is an [introduction course](http://lists.w3.org/Archives/Public/www-archive/2014Apr/0026.html)
+available which typically takes about 90 minutes to complete.

--- a/WorkMode/getting-started.md
+++ b/WorkMode/getting-started.md
@@ -4,7 +4,7 @@ layout: default
 # Welcome to the VC Working Group
 {: .no_toc}
 
-This document includes some information for new members of the DID Working
+This document includes some information for new members of the VC Working
 Group (VC WG).
 
 Members of the WG, **especially new members** are encouraged to help

--- a/WorkMode/guiding_principles.md
+++ b/WorkMode/guiding_principles.md
@@ -1,0 +1,127 @@
+---
+layout: default
+---
+
+# VC Working Group Guiding Principles
+{: .no_toc}
+
+This document sets down the current guiding principles in use by the VC
+Working Group to assist in making decisions about specification features.
+These guidelines provide a framework in which to have productive
+discussions that quickly come to consensus, rather than ending up blocked
+in an unresolvable tug-of-war over opposing and equally valid points of
+view. The principles are not meant to be interpreted as strict or objective
+rules, but instead as informative of the overall direction of the group to
+promote consistency and usability of the resulting specifications. 
+
+This document is a *Living Document* and as such will change. Members of
+the group are encouraged to edit (e.g., to update, correct, etc.) the
+information. Comments about this document are welcome via issues and pull
+request on the [group’s “admin” repository](https://github.com/w3c/verifiable-credentials/)
+or via emails sent to the group’s
+[`public-vc-wg@w3.org`](mailto:public-vc-wg@w3.org) e-mail list, using a
+subject prefix of <code>[Principles] …</code>.
+
+**Table of Content**
+* TOC
+{:toc}
+
+---
+
+## Stay on target!
+
+We follow our overall mission to standardize
+* the Verifiable Credentials Data Model (VCDM) 2.0, 
+* Securing Verifiable Credentials (SVC) 1.0, 
+
+**Notes**
+
+* 
+
+## Require real use cases, with actual instance data.
+
+Features are supported by real world use cases, with actual data that can
+be referenced. This helps reduce entirely theoretical features that might
+be implemented in libraries, but never used in practice by producers or
+consumers.
+
+**Notes**
+
+* Use cases should be supporting material which provides rationale for
+    decisions, and a teaching tool for when features might be useful. They
+    are not a design requirements gathering tool, and the group is not
+    starting from an empty slate.
+* These use cases are collected in a [Use Cases document](https://www.w3.org/TR/vc-use-cases/),
+    which has been published as a Note in the earlier phase of the Working Group.
+
+## Require at least two supporters for each use case.
+
+As the mission is interoperability, having at least two supporters for each
+use case is important. If only one supporter can be found, then any
+features that it would require are likely too specific for inclusion in the
+proposed form.
+
+**Notes**
+
+* Any independent organization, group, or individual can be a supporter,
+    regardless of whether they are part of the Working Group, or a member of
+    the W3C. Consortia or other standards organizations that represent many
+    participants can thus fulfill this principle via their members.
+* This is orthogonal to implementations of the specifications, which are
+    required to exit Candidate Recommendation phase.
+
+## As simple as possible, but no simpler.
+
+A solution that is simpler (to understand, implement, and use) is better than a more
+complex solution that accomplishes the same result.
+
+## Consistency is simpler than exceptions.
+
+Simplicity is considered in aggregate for the set of features defined by a
+specification, not independently.  If the same set of features can be
+accomplished by a smaller number of more consistent patterns, then that
+method is (very likely) simpler. Memorizing exceptions is harder than
+memorizing and applying rules.
+
+## Usability is determined by end users, not library implementers.
+
+Usability is determined by the target audience (data producers and
+consumers) based on their experience of understanding and applying the
+specification via existing implementations, not by the experience of
+implementers of the specification text directly. If there is a feature
+that makes it harder for implementations, but easier/better for end users,
+then that is a worthwhile trade off. We follow the HTML Design Pattern
+documents notion of the 
+[Priority of Constituencies](https://www.w3.org/TR/html-design-principles/#priority-of-constituencies),
+with an emphasis on trying to make things better for everyone. 
+
+**Notes**
+
+* Issues might arise where we need to prioritize between producers and consumers of the DID. The general feeling is that, in that situation, we should prioritize consumer happiness over producer happiness, i.e., the usability of the data, rather than ease of creation.
+  
+
+## Provide on-ramps.
+
+A solution that can be implemented in incremental stages is better than a
+solution that is all or nothing, as not everyone needs every feature but
+many people need various parts. Complex patterns should build upon simple
+ones, sometimes making the patterns more complicated than if they were
+built in isolation.
+
+## Define success, not failure.
+
+The specifications are defined in terms of what it means to be conformant,
+and not patterns that are not conformant. The fewer constraints we require,
+the easier to have non-breaking changes in the future and the easier it is
+to have experimentation. In a similar way to the distinction between Open
+World and Closed World, if something is not defined by the specification
+then it is permissible (just not standardized) rather than being disallowed.
+
+**Notes**
+
+* It is hard to judge when it is appropriate to be prescriptive, and when it is appropriate to be silent.
+
+## Follow existing standards and best practices, where possible and where they do not conflict with other principles.
+
+Between invention and reuse, pick reuse... unless that reuse would
+demonstrably harm adoption by being more complicated than necessary.

--- a/WorkMode/guiding_principles.md
+++ b/WorkMode/guiding_principles.md
@@ -97,7 +97,7 @@ with an emphasis on trying to make things better for everyone.
 
 **Notes**
 
-* Issues might arise where we need to prioritize between producers and consumers of the DID. The general feeling is that, in that situation, we should prioritize consumer happiness over producer happiness, i.e., the usability of the data, rather than ease of creation.
+* Issues might arise where we need to prioritize between producers and consumers of VCs. The general feeling is that, in that situation, we should prioritize consumer happiness over producer happiness, i.e., the usability of the data, rather than ease of creation.
   
 
 ## Provide on-ramps.

--- a/WorkMode/index.md
+++ b/WorkMode/index.md
@@ -1,0 +1,296 @@
+---
+layout: default
+---
+
+# VC Working Group Work mode
+{: .no_toc}
+
+This document defines and describes the VC WG's *Real Work Modes*, 
+including Participation and Communication, Meetings, Calls for Consensus, 
+Mail List usage, and links to important resources.
+
+Note that the [WG's Charter](https://www.w3.org{{ site.charter }}) formally
+defines the general framework of the group's working mode. In all cases,
+the Charter and/or the [W3C Process Document](//www.w3.org/Consortium/Process/) 
+overrides the information in this document. Nevertheless, this document
+contains additional information about how the group *really* works, so this
+information may be particularly useful to new members of the group.
+
+This document is a *Living Document* and as such will change. Members of
+the group are encouraged to edit (e.g., to update, correct, etc.) the
+information. Comments about this document are welcome via issues and pull
+requests on the [group’s “admin” repository](https://github.com/w3c/verifiable-credentials/)
+or via emails sent to the group’s [`public-vc-wg@w3.org`](mailto:public-vc-wg@w3.orgg)
+e-mail list, using a subject prefix of <code>[WorkMode]…</code>.
+
+**Table of Contents**
+* TOC
+{:toc}
+
+---
+
+## Participation and Communication
+
+The group's formal Participation and Communication models are documented in
+the [Participation](https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html#participation)
+and [Communications](https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html#communication)
+sections of its Charter, respectively.
+
+A WG member may participate in various ways including:
+
+* Attending any of the group‘s [weekly teleconferences or F2F meetings](../Meetings/)
+* Participating in discussions on the group’s primary mail lists (see below),
+    and/or a specification’s GitHub repository by way of Issues and Pull
+    Requests. (See the 
+    [list of all repositories](https://github.com/topics/vc-wg)
+    of this Group.) 
+* Participating in discussions on the group’s `#vc` IRC channel
+* Serving as a scribe during a WG meeting.
+* Being an Editor of one or more of the group’s active specifications
+* Being an implementer for one of the specifications (proof-of-concept
+    implementations are fine!)
+* Contributing tests for the group’s [specifications](https://www.w3.org/groups/wg/vc/publications)
+
+A WG member is added to the group’s lists `public-vc-wg@w3.org` and
+`member-vc-wg@w3.org`; see the [separate section](#communications) for
+more details. Other mailing lists may be set up for task forces or other
+sub-committees; signing up to those list must be done manually.
+
+Participation from the Public (i.e., non group members) via our Public
+e-mail lists is also welcome, provided comments, contributions, etc., are
+consistent with the [W3C Patent Policy](https://www.w3.org/TR/patent-policy/).
+
+### Information for New Group Members
+
+*New members of the group are strongly encouraged to read the group’s
+[Getting Started](getting-started) document which includes links to 
+important resources.* New members are also encouraged to send a short
+introductory e-mail to the group's 
+[public mailing list](https://lists.w3.org/Archives/Public/public-vc-wg/).
+
+## Communications
+
+### Meetings
+
+#### Teleconferences
+{: #telco}
+
+Teleconferences are held weekly at times agreed upon by the group. The
+meeting and its agenda are announced **at least 24 hours** before the
+meeting begins. Minutes are taken for every meeting and are automatically
+published after the meeting in a provisional format. A more readable,
+cleaned-up format is published usually within 24 hours after the meeting
+ends. 
+
+The charter also states that:
+
+> …any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+>
+> A call for consensus (CfC) will be issued for all resolutions (for example, via email and/or web-based survey), with a response period from 5 to 10 working days, depending on the chair's evaluation of the group consensus on the issue.
+>
+> If no objections are raised on the mailing list by the end of the response period, the resolution will be considered to have obtained consensus as a resolution of the Working Group.
+
+By default, publication of the meeting minutes is considered as a call for
+consensus for any formal resolution therein. However, depending on the
+assessment and the importance of a specific resolution at hand, the chairs
+may issue an more explicit CfC by email when the issue requires more
+details and explanations.
+
+#### Face-to-face meetings
+For Face-to-face meetings, there **should** be **8 weeks** notice of the
+city and date/time. Exact venue information is not required so early, but
+it is helpful, especially in large cities, so people traveling can find
+appropriate accommodations. The chairs and staff can help organize
+invitations for people who need them to obtain a visa, given sufficient
+notice.
+
+The consortium usually has an annual 
+[“Technical Plenary and All Working Group”](https://www.w3.org/2002/09/TPOverview.html)
+face-to-face meeting week (a.k.a “TPAC”) and this group typically has a f2f
+meeting during that week. The dates/locations are generally known a year or
+more in advance.
+
+For the minutes, resolutions, and consensus achieved at the f2f meetings,
+the same [rules](#telco) as for teleconferences apply.
+
+#### Scribing
+We encourage all WG members to take turns serving as scribe for meetings,
+and expect all WG members who are able to scribe to do so.
+
+### Public participation
+It is possible for people who are not members of the VC WG to follow the
+Working Group's work by signing up to the group's public mailing list,
+reading the mailing list archives, or watching the github issues. They can also
+raise issues on github, which the Working Group is required to answer
+within a reasonable time. The chairs of the Working Group may also
+occasionally invite them for a teleconference to, e.g., discuss those issues.
+In the case of a specific contribution to the specification in the form of,
+e.g., a Pull Request, see the
+[separate text](https://github.com/w3c/verifiable-credentials/blob/master/CONTRIBUTING.md)
+for the modalities.
+
+It is also possible for people who are not members of the VC WG to attend
+face-to-face meetings as observers. Non-members have not made any commitment
+to provide standard W3C royalty-free licensing, so non-members are restricted
+to observer status only. Observers may listen, and participate in general
+discussions during the meeting. However, they must not make technical
+contributions, nor attempt to influence an approach, to a feature that may
+become part of the specification being discussed.
+
+If the public contributor, or the observer, works for a W3C member company,
+they are encouraged to ask their Advisory Committee (AC) representative to
+make them a VC WG participant.
+
+Please note that this is to provide as much protection as possible through
+the W3C Patent Policy. We take the royalty-free status of W3C standards
+very seriously, and any attempt to work around these basic requirements
+would be considered a serious breach of meeting participation.
+
+### GitHub
+{: #github}
+
+The WG cannot make progress only during its weekly teleconferences. The
+group makes extensive use of GitHub. Each major deliverable is managed
+in its own, separate repository (a 
+[complete list of repositories](https://www.w3.org/PM/Groups/repositories.html?gid=98922)
+is available). The group intends to use the repositories’ issue management
+extensively to discuss technical problems and propose solutions. It is
+expected that most of this discussion will occur outside of our regular
+meeting times. 
+
+Editors of the documents (as well as the chairs and the W3C staff) have the
+necessary access rights to make editorial changes on the specifications
+directly using the standard Git(Hub) commits and by merging pull requests.
+Other members of the group are encouraged to use the
+[“fork and pull model”](https://help.github.com/articles/about-collaborative-development-models/)
+when contributing to the text: work on a forked repository and issue a pull
+request on the main repository for that document when the contribution is
+ready. Editors should use the pull request mechanism (except for obvious,
+grammatical, or stylistic changes), albeit they can choose to do that
+directly on the core repository (i.e., without creating a distinct fork).
+
+(If you are new to GitHub, the
+[*“Introduction to Basic GitHub Contribution”*](https://iherman.github.io/misc-notes/docs/BasicGitHubContributionIntro)
+may be of help.)
+
+In line with the spirit of the asynchronous decision procedures outlined
+above, significant pull requests, as well as the closure of open issues,
+should be marked with a special label (to be defined) and left open for a
+week. If no objection is raised during that time, the issue can be closed or
+the pull request can be merged, respectively.
+
+The recommended way to interact with a VC WG github repository is to
+follow the [standard github flow](https://guides.github.com/introduction/flow/).
+We strongly encourage members to use
+[their own fork of the WG repo](https://guides.github.com/activities/forking/).
+
+#### Issue labels
+GitHub issues are also used as a record of wide reviews, of horizontal
+reviews, etc. The Working Group will define a number of labels (e.g.,
+labeling an issue as part of the Horizontal Security review). Chairs,
+staff, and editors are responsible to set those labels accordingly.
+Similarly, when issues are waiting for external reviewers to react, labels
+will be used to signal the status of the issue. (See the
+[current set of labels](https://github.com/w3c/vc-data-model/labels).)
+
+### Mailing lists (Policy, Usage, Etiquette, etc.)
+
+Although it is expected that a large portion of the technical discussion
+will happen via the issues mechanism of GitHub, the primary mailing list
+may also be used for overarching technical as well as business, outreach,
+administrative, etc., topics. We expect our mail list participants to
+adhere to the following email etiquette:
+
+* Messages should be encoded using [plain text](http://en.wikipedia.org/wiki/Plain_text). 
+    Formats using [*rich text*](https://en.wikipedia.org/wiki/Rich_Text_Format)
+    will be lost by the list archives and appear poorly to many readers
+    before they get that far.
+* Subjects should be prefaced with the *short name* of the spec, if
+    applicable (for example: `[Spec] Blah, Blah, Blah`)
+* When you reply to a message, please use “> ” as your quotation character.
+* Do not prefix your content with something like “[myname]”. Your content
+    will be visible to everyone because it will *not* be prefixed by the
+    quotation character (“> ”).
+* Do strip quoted text which is not relevant to your reply.
+* Do not write in ALL CAPS. It is considered bad form. If you need to
+    \_underscore\_ something, you can do so as such, if you wanted to
+    \*strengthen\* something you can similarly, and if you want to provide
+    a certain \/italics\/ style, you may do that as well.
+* Your messages are archived. If you need to include links within your
+    message, please use `[n]` notation inline (e.g., [1]), and include the
+    relevant links at the end of the message. (Just like in a scholarly paper…)
+* Attachments must follow the 
+    [W3C Guidelines for Email Attachment Formats](https://www.w3.org/2002/03/email_attachment_formats.html),
+    in particular:
+	* Avoid unnecessary email attachments.
+	* Use an attachment only when it is likely to benefit to recipients.
+	    Otherwise, place the information (in plain text format) in the body
+	    of your message.
+	* If an attachment is necessary, avoid formats that are virus prone,
+	    proprietary or platform dependent.  For example, whenever possible
+	    you should use HTML instead of MS Word, PowerPoint or PDF.
+	* Follow [Web Content Accessibility Guidelines](//www.w3.org/TR/WAI-WEBCONTENT/) (WCAG)
+
+### IRC
+{: #irc}
+
+The group uses the `#vc` channel of the W3C’s IRC system (irc.w3.org; port 6667).
+Task forces may freely set up their own, specific channels.
+
+An [HTML interface to the W3C's IRC system](http://irc.w3.org/) is
+available. See [Meeting Resources](../Meetings/) for more information about
+the W3C’s IRC system and its usage.
+
+### Wiki(s)
+
+Each repository, including the “core” WG repository, has a wiki instance.
+Members of the Working Groups are encouraged to use those for temporary
+discussions, documents, etc. Pages on the repository Wikis have no formal
+status.
+
+## Process
+
+The [Charter](https://www.w3.org{{ site.charter }}) and the
+[W3C Process Document](https://www.w3.org/Consortium/Process/) are the
+final arbiters of any process question; however, the Working Group has
+adopted some complimentary, additional processes to aid in its productivity.
+
+* Adoption of [guiding technical principles](guiding_principles) towards
+    quickly coming to consensus
+* In order to balance the need for group consensus and the need to move the
+    work forward at a reasonable pace, we will not require most of the
+    group's decisions to be made via formal resolutions. 
+    * This will free the Editors to merge PRs and close Issues as soon as
+        they feel the group has reached consensus.
+    * Editors will attempt to reach out to interested parties, but it is up
+        to WG members to actively monitor progress.
+    * Any decision to merge may be challenged during a 48-hour window
+        following the decision.
+* It is encouraged that any Pull Request which changes the normative text
+    of the [DID Specification](https://github.com/w3c/vc-data-model/) be
+    accompanied by an equivalent Pull Request which changes the appropriate
+    tests in the [Test Suite](https://github.com/w3c/vc-test-suite/).
+    
+
+
+## Patent Policy
+
+The WG's Charter defines the
+[Patent Policy for this group](https://www.w3.org{{ site.charter }}#patentpolicy):
+
+> This Working Group operates under the [W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy-20200915/) (15 September 2020 Version). To promote the widest adoption of Web standards, W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis. For more information about disclosure obligations for this group, please see the [W3C Patent Policy Implementation](//www.w3.org/2004/01/pp-impl/).
+
+A consequence of the group’s Patent Policy is that, although comments from
+non-WG participants are welcome in general, specific contributions for the
+group's specifications from non-WG participants are not permitted. See the
+W3C Patent Policy FAQ titled
+[*How should Working Groups handle contributions from non-participants (e.g., meeting guests or on public lists)?*](https://www.w3.org/2003/12/22-pp-faq.html#non-participants)
+for more information about contributions from non-WG participants. Non-WG
+participants may contribute to the group's specifications if they have
+agreed to the terms in
+[*Licensing commitments from non-W3C Members*](https://www.w3.org/2004/01/pp-impl/100074/nmlc).
+
+## Code of Conduct
+
+The WG follows the W3C
+[Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/).

--- a/WorkMode/index.md
+++ b/WorkMode/index.md
@@ -5,7 +5,7 @@ layout: default
 # VC Working Group Work mode
 {: .no_toc}
 
-This document defines and describes the VC WG's *Real Work Modes*, 
+This document defines and describes the VCWG's *Real Work Modes*, 
 including Participation and Communication, Meetings, Calls for Consensus, 
 Mail List usage, and links to important resources.
 
@@ -267,7 +267,7 @@ adopted some complimentary, additional processes to aid in its productivity.
     * Any decision to merge may be challenged during a 48-hour window
         following the decision.
 * It is encouraged that any Pull Request which changes the normative text
-    of the [DID Specification](https://github.com/w3c/vc-data-model/) be
+    of the [VC Data Model](https://github.com/w3c/vc-data-model/) be
     accompanied by an equivalent Pull Request which changes the appropriate
     tests in the [Test Suite](https://github.com/w3c/vc-test-suite/).
     

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 baseurl: /2017/vc/WG
 groupid: 98922
-charter: /2020/12/verifiable-credentials-wg-charter.html
+charter: /2022/06/verifiable-credentials-wg-charter.html
 wgname_lc: vc
 wgname_uc: VC
 mission: "The mission of the Verifiable Credentials (formerly known as Verifiable Claims) Working Group (VCWG) is to make expressing and exchanging credentials that have been verified by a third party easier and more secure on the Web. The Working Group is now in maintenance mode."

--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -10,7 +10,7 @@
 
             <h3>Github repositories</h3>
             <ul>
-                <li><a href="https://github.com/search?q=verifiable-credentials+org%3Aw3c&type=Repositories">List of WG repositories</a>.</li>
+                <li><a href="https://www.w3.org/PM/Groups/repositories.html?gid=98922">List of WG repositories</a>.</li>
             </ul>
 
         </aside>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,20 +2,12 @@
     <h3>Getting involved</h3>
     <ul>
         <li><a href="https://www.w3.org/2017/vc/WG/">Group Home Page</a></li>
-        <li><a href="https://github.com/search?q=verifiable-credentials+org%3Aw3c&type=Repositories">Github repositories</a></li>
-	<!--*
-	<li><a href="https://www.w3.org/publishing/groups/publ-wg/Meetings/">Information on meetings</a></li>*-->
+        <li><a href="https://www.w3.org/PM/Groups/repositories.html?gid=98922">Github repositories</a></li>
+	    <li><a href="https://www.w3.org/2017/vc/WG/Meetings/">Information on meetings</a></li>
 	    <li><a href="https://www.w3.org/2017/vc/WG/Meetings/Minutes/">Meeting minutes</a></li>
-	<!--*
-	<li><a href="https://github.com/w3c/publ-wg/wiki">WG Wiki</a></li>*-->
-	<!--*
-        <li><a href="https://www.w3.org/publishing/groups/publ-wg/WorkMode/">WorkMode</a></li>
-	*-->
-	<!--*
-        <li><a href="https://www.w3.org/publishing/groups/publ-wg/Misc/presentations">Public Presentations</a></li>
-	*-->
+        <li><a href="https://www.w3.org/2017/vc/WG/WorkMode/">Work Mode</a></li>
         <li><a href="https://www.w3.org/2004/01/pp-impl/98922/join">Join the Working Group</a></li>
-	<li><a href="https://www.w3.org/Consortium/cepc/">W3C Code of Conduct</a></li>
+	    <li><a href="https://www.w3.org/Consortium/cepc/">W3C Code of Conduct</a></li>
     </ul>
 
     <h3>Documents and drafts</h3>
@@ -48,23 +40,12 @@
         <li><a href="https://www.w3.org/2004/01/pp-impl/98922/status">Patent Policy Status</a></li>
     </ul>
 
-
-    <h3>Face-to-face meetings</h3>
-    <ul>
-        <li><a href="https://www.w3.org/2017/vc/WG/Meetings/F2F/201804f2f.html">April 6, 2018 (Mountain View)</a></li>
-	    <li><a href="https://www.w3.org/2017/vc/WG/Meetings/F2F/2019-03-Barcelona">March 4-5, 2019 (Barcelona)</a></li>
-    </ul>
-
-    <!--* this could include web payments and credentials maybe?? *-->
-    <!--*
     <h3>Nearby</h3>
     <ul>
-        <li><a href="https://www.w3.org/publishing/">Publishing@W3C</a></li>
-        <li><a href="https://www.w3.org/publishing/groups/publ-bg/">Publishing Business Group</a></li>
-        <li><a href="https://www.w3.org/publishing/groups/publ-cg/">EPUB 3 Community Group</a></li>
-        <li><a href="https://www.w3.org/TR/#tr_Digital_Publishing">Publishing@W3C Publications</a></li>
+        <li>RDF Canonicalization and Hash (RCH) Working Group (t.b.d.)</li>
+        <li><a href="https://w3c-ccg.github.io/">W3C Credentials Community Group</a></li>
+        <li><a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a></li>
     </ul>
-    *-->
 
     <h3>General Links</h3>
     <ul>

--- a/assets/98922
+++ b/assets/98922
@@ -1,4 +1,4 @@
-Welcome to the W3C Verifiable Credentials (formerly Verifiable Claims) Working Group!
+Welcome to the W3C Verifiable Credentials Working Group!
 
 We are delighted to have you join us. Our mission is is to is to make expressing and exchanging credentials that have been verified by a third party easier and more secure on the Web.
 

--- a/assets/98922
+++ b/assets/98922
@@ -34,7 +34,7 @@ All participants are required to follow the W3C Code of Ethics and Professional 
 Should you have any questions on how to get up to speed with the group, please get in touch with us, e.g., by using the chairs' mailing list:
   group-vc-wg-chairs@w3.org
 
-Dan, Brent, and Ivan
+Brent, Kristina and Ivan
 
 
 

--- a/assets/98922
+++ b/assets/98922
@@ -1,0 +1,40 @@
+Welcome to the W3C Verifiable Credentials (formerly Verifiable Claims) Working Group!
+
+We are delighted to have you join us. Our mission is is to is to make expressing and exchanging credentials that have been verified by a third party easier and more secure on the Web.
+
+Our co-chairs are Kristina Yasuda (Microsoft) and Brent Zundel (Avast). The staff contact is Ivan Herman.
+
+You will find all information on the Working Group on the Group's home page:
+
+  https://www.w3.org/2017/vc/WG/
+
+In particular, you can find:
+
+"getting started" in the Working Group
+  https://www.w3.org/2017/vc/WG/WorkMode/getting-started/
+
+Working Group's working modes
+  https://www.w3.org/2017/vc/WG/WorkMode/
+
+meeting schedules and details:
+  https://www.w3.org/2017/vc/WG/Meetings/
+
+publication status and milestones:
+  https://www.w3.org/groups/wg/vc/publications
+
+current participants:
+  https://www.w3.org/groups/wg/vc/participants?sortaff=1
+
+list of the group repositories on github:
+  https://github.com/topics/vc-wg
+
+All participants are required to follow the W3C Code of Ethics and Professional Conduct:
+  https://www.w3.org/Consortium/cepc/
+
+Should you have any questions on how to get up to speed with the group, please get in touch with us, e.g., by using the chairs' mailing list:
+  group-vc-wg-chairs@w3.org
+
+Dan, Brent, and Ivan
+
+
+


### PR DESCRIPTION
I have made a bunch of updates on the WG's Web Site, mostly inspired by the, and, in some cases, copy from the DID WG pages. Because there are cuts and pastes, would be nice if the changes were reviewed to catch mistakes. The changes are as follows:

- Created the "98922" file in the assets folder. This file can be used as the welcome text for new members, instead of the run-of-the-mill pages generated automatically. (Actually, the creation of that file triggered the other changes, hence the name of the branch:-)
- Refreshed the Meetings/index page now that we are real WG again.
- Added a Meetings/zoom page as a short notice on how to use zoom
- Added a WorkMode/index page, that proved to be fairly useful in the DID WG, at least at the beginning. DanB and Brent put a lot of work into this one; I think, at least as a start, it should be o.k. to just reuse it with the obvious contextual changes.
- There are two more pages in the WorkMode folder, namely getting-started and guiding_principles; again, these were used in the DID WG and proved to be useful (at least as a reference).

I also made some updates on the navigation bar entries, but those are routine, does not need real review.